### PR TITLE
throw error when calling define with too few arguments

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -408,6 +408,9 @@ var requirejs, require, define;
     requirejs._defined = defined;
 
     define = function (name, deps, callback) {
+        if (!deps) {
+            throw new Error('define called with too few arguments.');
+        }
 
         //This module may not have dependencies
         if (!deps.splice) {


### PR DESCRIPTION
To remedy the problem described in #99 we've added this patch to the almond we use in production.

It doesn't fix the problem, but it makes it easier for us to debug it and easier to categorize the error reports we get.

Our current feeling is that these errors originate from extensions fiddling around in our web app's context, but it's based on a few reports where we could actually see the extension id in the stack trace.

Even though almond is designed to run require.js applications after they have been built, it makes sense to safe guard it against evil extensions.