### PR TITLE
fixed broken map config resolution

### DIFF
--- a/almond.js
+++ b/almond.js
@@ -49,7 +49,6 @@ var requirejs, require, define;
                 //module. For instance, baseName of "one/two/three", maps to
                 //"one/two/three.js", but we want the directory, "one/two" for
                 //this normalization.
-                baseParts = baseParts.slice(0, baseParts.length - 1);
                 name = name.split('/');
                 lastIndex = name.length - 1;
 
@@ -58,7 +57,7 @@ var requirejs, require, define;
                     name[lastIndex] = name[lastIndex].replace(jsSuffixRegExp, '');
                 }
 
-                name = baseParts.concat(name);
+                name = baseParts.slice(0, baseParts.length - 1).concat(name);
 
                 //start trimDots
                 for (i = 0; i < name.length; i += 1) {

--- a/tests/mapConfig/mapConfig.js
+++ b/tests/mapConfig/mapConfig.js
@@ -44,6 +44,12 @@ define('a/sub/one',['c', 'c/sub'], function (c, csub) {
     };
 });
 
+define('d', ['./c'], function(c) {
+    return {
+        c: c
+    }
+});
+
 require({
         baseUrl: './',
         paths: {
@@ -56,11 +62,14 @@ require({
             },
             'a/sub/one': {
                 'c': 'c2'
+            },
+            'd': {
+                'c': 'c1'
             }
         }
     },
-    ['a', 'b', 'c', 'a/sub/one'],
-    function(a, b, c, one) {
+    ['a', 'b', 'c', 'a/sub/one', 'd'],
+    function(a, b, c, one, d) {
         doh.register(
             'mapConfig',
             [
@@ -72,6 +81,7 @@ require({
                     t.is('c', b.c.name);
                     t.is('c/sub', b.csub.name);
                     t.is('c', c.name);
+                    t.is('c1', d.c.name);
                 }
             ]
         );


### PR DESCRIPTION
While adjusting relative dependency names in normalize function the baseParts variable gets modified (last element gets removed). Later on baseParts are used again for checking the map config. But the code there expects the unmodified baseParts to find the correct configuration.

Example:
```javascript
//main.js
require.config({
  map: {
    a: {
      b: 'c'
    }
  }
});

require(['a'], function() {});
```
```javascript
//a.js
define(['./b'], function() {});
```
```javascript
//c.js
define([], function() {});
```

Almond throws "Uncaught Error: a missing b". It works with RequireJS (also optimized), therefore this seems not to be the expected behavior. If './b' is changed to 'b' it's also working in Almond.