### PR TITLE
fixed static connect server to make tests on travis CI run again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,28 +1,29 @@
 {
-    "name": "almond",
-    "description": "A minimal AMD API implementation for use in optimized browser builds.",
-    "version": "0.3.0",
-    "homepage": "http://github.com/jrburke/almond",
-    "author": "James Burke <jrburke@gmail.com> (http://github.com/jrburke)",
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/jrburke/almond.git"
+  "name": "almond",
+  "description": "A minimal AMD API implementation for use in optimized browser builds.",
+  "version": "0.3.0",
+  "homepage": "http://github.com/jrburke/almond",
+  "author": "James Burke <jrburke@gmail.com> (http://github.com/jrburke)",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jrburke/almond.git"
+  },
+  "licenses": [
+    {
+      "type": "BSD",
+      "url": "https://github.com/jrburke/almond/blob/master/LICENSE"
     },
-    "licenses": [
-        {
-            "type": "BSD",
-            "url": "https://github.com/jrburke/almond/blob/master/LICENSE"
-        },
-        {
-            "type": "MIT",
-            "url": "https://github.com/jrburke/almond/blob/master/LICENSE"
-        }
-    ],
-    "main": "almond.js",
-    "engines": {
-        "node": ">=0.4.0"
-    },
-    "devDependencies": {
-        "connect": "*"
+    {
+      "type": "MIT",
+      "url": "https://github.com/jrburke/almond/blob/master/LICENSE"
     }
+  ],
+  "main": "almond.js",
+  "engines": {
+    "node": ">=0.4.0"
+  },
+  "devDependencies": {
+    "connect": "^3.3.4",
+    "serve-static": "^1.9.1"
+  }
 }

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,3 +1,6 @@
-var connect = require('connect');
-connect.createServer(connect.static(__dirname + '/..')).listen(1986);
+var connect = require('connect'),
+    serveStatic = require('serve-static');
+var server = connect();
+server.use(serveStatic(__dirname + '/..'));
+server.listen(1986);
 require('fs').writeFileSync(__dirname + '/pid.txt', process.pid);


### PR DESCRIPTION
Npm configuration was configured to always install newest connect version. Since they changed connect API from version 2.x to 3.x the tests/server.js file was not working anymore. Therefore travis CI could not successfully run through the builds.
The problem should be fixed and npm is configured to update only minor connect releases, to prevent similar problems in future.