### PR TITLE
Updated nodejs version in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js:  0.8
+node_js:  0.10
 
 before_script:
   - node tests/server.js &


### PR DESCRIPTION
The old npm version doesn't support the minor releases version syntax for dependencies. Therefore installing "connect": "^3.3.4" and "serve-static": "^1.9.1" failed, which again resulted in broken builds. Sorry, didn't realize the incompatibility with the old node version in .travis.yml in the first pull request.